### PR TITLE
`subtractIntervals` to handle set subtraction

### DIFF
--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'vitest';
 import {
-  calculateScheduleOverlap, intersectSchedules, isInInterval, unionSchedules,
+  calculateScheduleOverlap,
+  intersectSchedules,
+  isInInterval,
+  subtractIntervals,
+  unionSchedules,
 } from './util';
 import { Interval, WeeklyTime } from './types';
 
@@ -103,5 +107,66 @@ describe('isInInterval', () => {
     expect(isInInterval([1, 5] as Interval, 0.999 as WeeklyTime)).toBe(false);
     expect(isInInterval([[1, 3], [5, 8]] as Interval[], 4 as WeeklyTime)).toBe(false);
     expect(isInInterval([[1, 3], [5, 8]] as Interval[], 9 as WeeklyTime)).toBe(false);
+  });
+});
+
+describe('subtractIntervals', () => {
+  test('returns availability unchanged when blocked is empty', () => {
+    const availability = [
+      [100, 200],
+      [300, 400],
+    ] as Interval[];
+    const blocked: Interval[] = [];
+    expect(subtractIntervals(availability, blocked)).toEqual([
+      [100, 200],
+      [300, 400],
+    ]);
+  });
+
+  test('returns availability unchanged when blocked is entirely before', () => {
+    const availability = [[200, 300]] as Interval[];
+    const blocked = [[0, 100]] as Interval[];
+    expect(subtractIntervals(availability, blocked)).toEqual([[200, 300]]);
+  });
+
+  test('returns availability unchanged when blocked is entirely after', () => {
+    const availability = [[100, 200]] as Interval[];
+    const blocked = [[300, 400]] as Interval[];
+    expect(subtractIntervals(availability, blocked)).toEqual([[100, 200]]);
+  });
+
+  test('removes start of availability when blocked overlaps beginning', () => {
+    const availability = [[100, 300]] as Interval[];
+    const blocked = [[50, 150]] as Interval[];
+    expect(subtractIntervals(availability, blocked)).toEqual([[150, 300]]);
+  });
+
+  test('removes end of availability when blocked overlaps end', () => {
+    const availability = [[100, 300]] as Interval[];
+    const blocked = [[250, 350]] as Interval[];
+    expect(subtractIntervals(availability, blocked)).toEqual([[100, 250]]);
+  });
+
+  test('removes availability when blocked covers', () => {
+    const availability = [[100, 200]] as Interval[];
+    const blocked = [[100, 200]] as Interval[];
+    expect(subtractIntervals(availability, blocked)).toEqual([]);
+  });
+
+  test('handles multiple availability and blocked intervals', () => {
+    const availability = [
+      [0, 200],
+      [300, 500],
+    ] as Interval[];
+    const blocked = [
+      [50, 100],
+      [350, 400],
+    ] as Interval[];
+    expect(subtractIntervals(availability, blocked)).toEqual([
+      [0, 50],
+      [100, 200],
+      [300, 350],
+      [400, 500],
+    ]);
   });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -82,3 +82,44 @@ const calculateIntervalOverlap = (intervals: Interval[]): IntervalOverlapResult[
 
   return (result as IntervalOverlapResult[]).filter((i) => i.count > 0 && i.interval[1] > i.interval[0]);
 };
+
+/** Subtract blocked intervals from availability intervals.
+ * Returns new availability with blocked times removed. */
+export function subtractIntervals(
+  availability: Interval[],
+  blocked: Interval[],
+): Interval[] {
+  if (blocked.length === 0) return availability;
+
+  const result: Interval[] = [];
+
+  /* eslint-disable no-restricted-syntax */
+  for (const [availStart, availEnd] of availability) {
+    let remaining: Interval[] = [[availStart, availEnd]];
+
+    for (const [blockStart, blockEnd] of blocked) {
+      const newRemaining: Interval[] = [];
+
+      for (const [remStart, remEnd] of remaining) {
+        // No overlap - keep the interval
+        if (blockEnd <= remStart || blockStart >= remEnd) {
+          newRemaining.push([remStart, remEnd]);
+        } else {
+          // Some overlap
+          if (remStart < blockStart) {
+            newRemaining.push([remStart, blockStart]);
+          }
+          if (remEnd > blockEnd) {
+            newRemaining.push([blockEnd, remEnd]);
+          }
+        }
+      }
+
+      remaining = newRemaining;
+    }
+
+    result.push(...remaining);
+  }
+
+  return result;
+}


### PR DESCRIPTION
During automated scheduling between facilitators and participants, we want to avoid considering times when facilitators are already running discussions.

One way to do this is to subtract existing facilitator discussions from available times:

Availability: Monday 9am-5pm
Blocked:     Monday 11am-1pm (existing round)
Result:        Monday 9am-11am, Monday 1pm-5pm

This PR adds a new utility, `subractIntervals`, to handle the set subtraction logic.