### PR TITLE
Parse "M00:00 M00:00" as full-week interval

### DIFF
--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -7,6 +7,7 @@ describe('format', () => {
     [540 as WeeklyTime, 'M09:00'],
     [1440 as WeeklyTime, 'T00:00'],
     [4321 as WeeklyTime, 'R00:01'],
+    [[0, 10080] as Interval, 'M00:00 M00:00'],
     [[540, 1440] as Interval, 'M09:00 T00:00'],
     [[[540, 1440]] as Interval[], 'M09:00 T00:00'],
     [[[540, 1440], [4321, 4322]] as Interval[], 'M09:00 T00:00, R00:01 R00:02'],

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -28,7 +28,7 @@ describe('parseIntervals', () => {
 
   describe('single intervals', () => {
     test.each([
-      ['M00:00 M00:00', [0, 0]],
+      ['M00:00 M00:00', [0, 168]], // full week: beginning === end === 0 is treated as wrap-around to end of week
       ['M00:00 M01:00', [0, 1]],
       ['M10:00 M15:00', [10, 15]],
       ['T00:00 R12:00', [24, 84]],

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -45,7 +45,7 @@ function parseInterval(interval: string): Interval {
   // If beginning > end, we have looped around the week
   // e.g. U23:00 M00:00
   // So the end of the interval should be the end of the week
-  if (beginning > end) {
+  if (beginning >= end) {
     if (end === 0) {
       // We handle this edge case because it is used to represent wrapping around to the end of the week, e.g. U23:00 M00:00
       // NB: we don't allow U23:00 M01:00 - this should be input as U23:00 M00:00, M00:00 M01:00


### PR DESCRIPTION
Change the wrap-around condition in parseInterval from `>` to `>=` so that [0, 10080] round-trips correctly through format/parse.

Closes #16.
